### PR TITLE
v1.5.1 - storage / user creation update

### DIFF
--- a/server/swagger_server/response_code/comanage_utils.py
+++ b/server/swagger_server/response_code/comanage_utils.py
@@ -524,3 +524,21 @@ def update_user_org_affiliations(fab_person: FabricPeople):
     except Exception as exc:
         details = 'Oops! something went wrong with update_user_subject_identities(): {0}'.format(exc)
         consoleLogger.error(details)
+
+
+def is_fabric_active_user(co_person_id: int) -> bool:
+    """
+    Check for active fabric-active-users role in COmanage
+    """
+    try:
+        co_roles = api.coperson_roles_view_per_coperson(coperson_id=co_person_id).get('CoPersonRoles', [])
+        for co_role in co_roles:
+            if int(co_role.get('CouId')) == int(os.getenv('COU_ID_ACTIVE_USERS')) and str(
+                    co_role.get('Status')).casefold() == 'active':
+                return True
+        return False
+
+    except Exception as exc:
+        details = 'Oops! something went wrong with is_fabric_active_user(): {0}'.format(exc)
+        consoleLogger.error(details)
+        return False

--- a/server/swagger_server/response_code/people_utils.py
+++ b/server/swagger_server/response_code/people_utils.py
@@ -7,8 +7,9 @@ from swagger_server.api_logger import consoleLogger, metricsLogger
 from swagger_server.database.db import db
 from swagger_server.database.models.people import FabricPeople, FabricRoles
 from swagger_server.database.models.projects import FabricProjects
-from swagger_server.response_code.comanage_utils import api, update_email_addresses, update_org_affiliation, \
-    update_people_identifiers, update_people_roles, update_user_org_affiliations, update_user_subject_identities
+from swagger_server.response_code.comanage_utils import api, is_fabric_active_user, update_email_addresses, \
+    update_org_affiliation, update_people_identifiers, update_people_roles, update_user_org_affiliations, \
+    update_user_subject_identities
 from swagger_server.response_code.preferences_utils import create_people_preferences
 from swagger_server.response_code.profiles_utils import create_profile_people
 from swagger_server.response_code.vouch_utils import vouch_get_custom_claims
@@ -89,7 +90,7 @@ def create_fabric_person_from_login(claims: dict = None) -> FabricPeople:
             # search for person by email
             co_person = api.copeople_match(
                 mail=claims.get('email')).get('CoPeople', [])
-            if co_person:
+            if co_person and is_fabric_active_user(co_person_id=co_person[0].get('Id')):
                 fab_person = create_fabric_person_from_co_person_id(co_person_id=co_person[0].get('Id'))
                 fab_person.oidc_claim_email = claims.get('email')
                 fab_person.oidc_claim_sub = claims.get('sub')

--- a/server/swagger_server/response_code/storage_controller.py
+++ b/server/swagger_server/response_code/storage_controller.py
@@ -152,6 +152,13 @@ def storage_post(body: StoragePost = None) -> Storage:  # noqa: E501
         fab_project = FabricProjects.query.filter_by(uuid=body.project_uuid).one_or_none()
         if not fab_project:
             return cors_404(details="No match for project_uuid with uuid = '{0}'".format(body.project_uuid))
+        # check for duplicate entry
+        if FabricStorage.query.filter(
+                FabricStorage.project_id == fab_project.id,
+                FabricStorage.volume_name == body.volume_name
+        ).first():
+            return cors_400(details="Storage already exists (Duplicate): project_uuid='{0}', volume_name='{1}'".format(
+                body.project_uuid, body.volume_name))
         # check requested_by_uuid
         fab_person = FabricPeople.query.filter_by(uuid=body.requested_by_uuid).one_or_none()
         if not fab_person:


### PR DESCRIPTION
- Duplicate storage POST calls generate a 400 response instead of a 500 response
- User creation is delayed on the core-api side until a CoPerson has an "active" `fabric-active-users role` (not just the role)