### PR TITLE
Correcting tag names and descriptions (primarily for CloudLab-Clemson)

### DIFF
--- a/server/swagger_server/response_code/json_data/projects_tags_production.json
+++ b/server/swagger_server/response_code/json_data/projects_tags_production.json
@@ -23,8 +23,8 @@
     "Net.FacilityPort.Cloud-Facility-Azure": "Microsoft Azure Cloud Production",
     "Net.FacilityPort.RCNF": "Rutgers CryoEM & Nanoimaging Facility (RCNF)",
     "Net.FacilityPort.OCT-MGHPCC": "Massachusetts Green High Performance Computing Center (MGHPCC)",
-    "Net.FacilityPort.Clemson-CloudLab": "Clemson-CloudLab Production",
-    "Net.FacilityPort.CloudLab-UWisc-Madison": "Wisconsin-Cloudlab Production",
-    "Net.FacilityPort.ASU-Research-Network-FABRIC": "Wisconsin-Cloudlab Production"
+    "Net.FacilityPort.CloudLab-Clemson": "CloudLab-Clemson Production",
+    "Net.FacilityPort.CloudLab-UWisc-Madison": "Cloudlab-Wisconson Production",
+    "Net.FacilityPort.ASU-Research-Network-FABRIC": "ASU Production"
   }
 }


### PR DESCRIPTION
Fixed the spelling of CloudLab-Clemson facility port tag and descriptions for two others. Please deploy when possible.