### PR TITLE
Adding EDC and EDUKY to the list of sites

### DIFF
--- a/server/swagger_server/response_code/json_data/projects_tags_base.json
+++ b/server/swagger_server/response_code/json_data/projects_tags_base.json
@@ -29,6 +29,6 @@
     "Slice.Multisite": "allows to create slices spanning multiple sites",
     "Slice.Measurements": "allows to provision measurement VMs",
     "Slice.NoLimitLifetime": "allows to create slices with a lifetime beyond default limit X time units without the need to renew",
-    "Project.Educational": "tags the project as being educational, rather than research"
+    "Slice.OnlyEDUKY": "allows to create slices only on EDUKY"
   }
 }

--- a/server/swagger_server/response_code/json_data/storage_sites.json
+++ b/server/swagger_server/response_code/json_data/storage_sites.json
@@ -44,6 +44,8 @@
     "BRIST": "Bristol",
     "AMST": "University of Amsterdam",
     "TOKY": "The University of Tokyo",
-    "HAWI": "Hawaii"
+    "HAWI": "Hawaii",
+    "EDC": "Experimenter Data Cluster at NCSA",
+    "EDUKY": "Educational site at UKY"
   }
 }


### PR DESCRIPTION
@mjstealey can you also update existing projects that have `Project.Educational` to have `Slice.OnlyEDUKY` instead?